### PR TITLE
Replace base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.19
+FROM public.ecr.aws/docker/library/golang:1.21.1
 
 # Set destination for COPY
 WORKDIR /app


### PR DESCRIPTION
Due to docker hub limitations, building with golang image fails. The solution is to use public ecr image to avoid `toomanyrequests` error.